### PR TITLE
Add default linter rules plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Checkout our [contribution guidelines](#contribute) to add more plugins to the l
 
 ### Linter Rules
 
-* [Default Linter Rules Plugin](https://github.com/jonathanlukas/camunda-modeler-linter-default-rules) - A Camunda Modeler Linter Rules Plugin that activates the default linter rules from former linter plugin versions.
+* [Default Linter Rules Plugin](https://github.com/jonathanlukas/camunda-modeler-linter-default-rules) - A Camunda Modeler plugin that contributes the default linter rules (formerly provided through the linter plug-in).
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Checkout our [contribution guidelines](#contribute) to add more plugins to the l
 * [DMN Testing Plugin](https://github.com/bpmn-io/dmn-testing-plugin) - A Camunda Modeler plugin to test your DMN decision tables and decision graphs using an embedded Camunda decision engine.
 * [Excel Import Plugin](https://github.com/pinussilvestrus/camunda-modeler-excel-import-plugin) - Camunda Modeler Plugin to import Excel Sheets to DMN Tables.
 
+### Linter
+
+* [Default Linter Rules Plugin](https://github.com/jonathanlukas/camunda-modeler-linter-default-rules) - A Camunda Modeler Linter Rules Plugin that activates the default linter rules from former linter plugin versions.
+
 ## Contribute
 
 Would you like to contribute to this list? [Propose your addition](https://github.com/camunda/camunda-modeler/edit/master/README.md) by editing the plugins list.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Checkout our [contribution guidelines](#contribute) to add more plugins to the l
 * [DMN Testing Plugin](https://github.com/bpmn-io/dmn-testing-plugin) - A Camunda Modeler plugin to test your DMN decision tables and decision graphs using an embedded Camunda decision engine.
 * [Excel Import Plugin](https://github.com/pinussilvestrus/camunda-modeler-excel-import-plugin) - Camunda Modeler Plugin to import Excel Sheets to DMN Tables.
 
-### Linter
+### Linter Rules
 
 * [Default Linter Rules Plugin](https://github.com/jonathanlukas/camunda-modeler-linter-default-rules) - A Camunda Modeler Linter Rules Plugin that activates the default linter rules from former linter plugin versions.
 

--- a/plugins.json
+++ b/plugins.json
@@ -177,6 +177,14 @@
       "description": "Camunda Modeler plugin to import Excel Sheets to DMN 1.3 Decision Tables (and vice versa).",
       "url": "https://github.com/pinussilvestrus/camunda-modeler-excel-import-plugin",
       "category": "DMN"
+    },
+    {
+      "id": "camunda-modeler-linter-default-rules",
+      "displayName": "Default Rules Plugin",
+      "version": "0.0.0",
+      "description": "A Camunda Modeler linter rules plugin that activates the default linter rules from former linter plugin versions",
+      "url": "https://github.com/jonathanlukas/camunda-modeler-linter-default-rules",
+      "category": "BPMN"
     }
   ]
 }

--- a/plugins.json
+++ b/plugins.json
@@ -182,7 +182,7 @@
       "id": "camunda-modeler-linter-default-rules",
       "displayName": "Default Rules Plugin",
       "version": "0.0.0",
-      "description": "A Camunda Modeler linter rules plugin that activates the default linter rules from former linter plugin versions",
+      "description": "Activates the default BPMN linter rules (formerly provided through the linter plugin)",
       "url": "https://github.com/jonathanlukas/camunda-modeler-linter-default-rules",
       "category": "BPMN"
     }

--- a/plugins.json
+++ b/plugins.json
@@ -180,7 +180,7 @@
     },
     {
       "id": "camunda-modeler-linter-default-rules",
-      "displayName": "Default Rules Plugin",
+      "displayName": "Default Linter Rules Plugin",
       "version": "0.0.0",
       "description": "Activates the default BPMN linter rules (formerly provided through the linter plugin)",
       "url": "https://github.com/jonathanlukas/camunda-modeler-linter-default-rules",


### PR DESCRIPTION
Adds a link to the `plugins.json` as well as `README.md`.

Note: Does create a new category "Linter Rules".