### PR TITLE
chore: add Data Outline Plugin to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Checkout our [contribution guidelines](#contribute) to add more plugins to the l
 * [Reduced Palette](https://github.com/camunda-community-hub/camunda-modeler-plugin-reduced-palette) - A plugin that reduces the number of available entries in the palette and the context menu.
 * [Technical ID Generator](https://github.com/camunda-community-hub/camunda-modeler-plugin-rename-technical-ids) - A plugin that generates technical IDs for BPMN elements according to best practices.
 * [Tooltip Plugin](https://github.com/viadee/camunda-modeler-tooltip-plugin) - Adds tooltips to various BPMN elements revealing hidden properties and conditional flows.
+* [Data Outline Plugin](https://github.com/marstamm/camunda-modeler-data-outline-plugin) - Adds a tree-view for variables in Camunda 8 to the bottom panel.
 
 ### dmn-js
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Checkout our [contribution guidelines](#contribute) to add more plugins to the l
 * [Reduced Palette](https://github.com/camunda-community-hub/camunda-modeler-plugin-reduced-palette) - A plugin that reduces the number of available entries in the palette and the context menu.
 * [Technical ID Generator](https://github.com/camunda-community-hub/camunda-modeler-plugin-rename-technical-ids) - A plugin that generates technical IDs for BPMN elements according to best practices.
 * [Tooltip Plugin](https://github.com/viadee/camunda-modeler-tooltip-plugin) - Adds tooltips to various BPMN elements revealing hidden properties and conditional flows.
-* [Data Outline Plugin](https://github.com/marstamm/camunda-modeler-data-outline-plugin) - Adds a tree-view for variables in Camunda 8 to the bottom panel.
+* [Data Outline Plugin](https://github.com/camunda/camunda-modeler-data-outline-plugin) - Adds a tree-view for variables in Camunda 8 to the bottom panel.
+
 
 ### dmn-js
 

--- a/plugins.json
+++ b/plugins.json
@@ -159,7 +159,7 @@
       "displayName": "Camunda Modeler Data Outline Plugin",
       "version": "0.0.1",
       "description": "Adds a tree-view for variables in Camunda 8 to the bottom panel.",
-      "url": "https://github.com/marstamm/camunda-modeler-data-outline-plugin",
+      "url": "https://github.com/camunda/camunda-modeler-data-outline-plugin",
       "category": "BPMN"
     },
     {

--- a/plugins.json
+++ b/plugins.json
@@ -155,6 +155,14 @@
       "category": "BPMN"
     },
     {
+      "id": "camunda-modeler-data-outline-plugin",
+      "displayName": "Camunda Modeler Data Outline Plugin",
+      "version": "0.0.1",
+      "description": "Adds a tree-view for variables in Camunda 8 to the bottom panel.",
+      "url": "https://github.com/marstamm/camunda-modeler-data-outline-plugin",
+      "category": "BPMN"
+    },
+    {
       "id": "camunda-modeler-dmn-js-plugin-example",
       "displayName": "Camunda Modeler dmn-js Plugin Example",
       "version": "0.1.0",


### PR DESCRIPTION
Adds the data outline Plugin to the list of Plugins
![screencast](https://github.com/camunda/camunda-modeler-plugins/assets/21984219/379a371f-5f1c-45d2-a224-b47ebe0119b0)
